### PR TITLE
Adds #performer and #title methods for main metadata

### DIFF
--- a/lib/rubycue/cuesheet.rb
+++ b/lib/rubycue/cuesheet.rb
@@ -42,7 +42,7 @@ module RubyCue
       end
     end
 
-    private
+  private
 
     def calculate_song_durations!
       @songs.each_with_index do |song, i|

--- a/lib/rubycue/cuesheet.rb
+++ b/lib/rubycue/cuesheet.rb
@@ -1,6 +1,6 @@
 module RubyCue
   class Cuesheet
-    attr_reader :cuesheet, :songs, :track_duration
+    attr_reader :cuesheet, :songs, :track_duration, :performer
 
     def initialize(cuesheet, track_duration=nil)
       @cuesheet = cuesheet      
@@ -69,7 +69,7 @@ module RubyCue
     def parse_performers
       unless @performers
         @performers = cuesheet_scan(:performer).map{|performer| performer.first}
-        @performers.delete_at(0)
+        @performer = @performers.delete_at(0)
       end
       @performers
     end

--- a/lib/rubycue/cuesheet.rb
+++ b/lib/rubycue/cuesheet.rb
@@ -1,6 +1,6 @@
 module RubyCue
   class Cuesheet
-    attr_reader :cuesheet, :songs, :track_duration, :performer
+    attr_reader :cuesheet, :songs, :track_duration, :performer, :title
 
     def initialize(cuesheet, track_duration=nil)
       @cuesheet = cuesheet      
@@ -61,7 +61,7 @@ module RubyCue
     def parse_titles
       unless @titles
         @titles = cuesheet_scan(:title).map{|title| title.first}
-        @titles.delete_at(0)
+        @title = @titles.delete_at(0)
       end
       @titles
     end

--- a/spec/unit/cuesheet_spec.rb
+++ b/spec/unit/cuesheet_spec.rb
@@ -22,6 +22,10 @@ describe RubyCue::Cuesheet do
         @cuesheet.performer.should == 'Netsky'
       end
 
+      it "has the main title" do
+        @cuesheet.title.should == 'Essential Mix (2010-10-09)'
+      end
+
       it "has the right first track" do
         @cuesheet.songs.first[:title].should == "Intro"
       end

--- a/spec/unit/cuesheet_spec.rb
+++ b/spec/unit/cuesheet_spec.rb
@@ -17,6 +17,10 @@ describe RubyCue::Cuesheet do
       it "returns true if successfully parsed" do
         @cuesheet.parse!.should be_true
       end
+      
+      it "has the main performer" do
+        @cuesheet.performer.should == 'Netsky'
+      end
 
       it "has the right first track" do
         @cuesheet.songs.first[:title].should == "Intro"


### PR DESCRIPTION
This pull request adds an extra 2 methods:
- `RubyCue::Cuesheet#performer`
- `RubyCue::Cuesheet#title`

Originally when parsing the first performer and title matches, they were removed. I've added the methods above that can be used to return metadata for the entire cue sheet and not just the individual songs.
